### PR TITLE
Bugfix/913 914 gateway redeem tx

### DIFF
--- a/sdk/src/contexts/cosmos/context.ts
+++ b/sdk/src/contexts/cosmos/context.ts
@@ -12,7 +12,6 @@ import {
   Coin,
   IbcExtension,
   QueryClient,
-  StargateClient,
   StdFee,
   calculateFee,
   logs as cosmosLogs,
@@ -117,13 +116,9 @@ export class CosmosContext<
     txId: string,
     chain: ChainName | ChainId,
   ): Promise<BigNumber | undefined> {
-    const chainName = this.context.toChainName(chain);
-    const rpc = this.context.conf.rpcs[chainName];
-    if (rpc) {
-      const client = await StargateClient.connect(rpc);
-      const transaction = await client.getTx(txId);
-      return BigNumber.from(transaction?.gasUsed || 0);
-    }
+    const client = await this.getCosmWasmClient(chain);
+    const transaction = await client.getTx(txId);
+    return BigNumber.from(transaction?.gasUsed || 0);
   }
 
   send(

--- a/wormhole-connect/src/utils/events.ts
+++ b/wormhole-connect/src/utils/events.ts
@@ -13,7 +13,8 @@ import { CHAINS } from 'config';
 import { fetchGlobalTx, getEmitterAndSequence } from './vaa';
 import { isEvmChain } from 'utils/sdk';
 import { isCosmWasmChain } from './cosmos';
-import { CosmosGatewayRoute, SignedMessage } from './routes';
+import { CosmosGatewayRoute } from './routes/cosmosGateway';
+import { SignedMessage } from './routes/types';
 
 export const fetchRedeemTx = async (
   txData: SignedMessage,

--- a/wormhole-connect/src/utils/events.ts
+++ b/wormhole-connect/src/utils/events.ts
@@ -7,14 +7,16 @@ import {
   SeiContext,
   WormholeContext,
 } from '@wormhole-foundation/wormhole-connect-sdk';
-import { ParsedMessage, ParsedRelayerMessage, PayloadType, wh } from './sdk';
+import { PayloadType, wh } from './sdk';
 import { fromNormalizedDecimals } from '.';
 import { CHAINS } from 'config';
 import { fetchGlobalTx, getEmitterAndSequence } from './vaa';
 import { isEvmChain } from 'utils/sdk';
+import { isCosmWasmChain } from './cosmos';
+import { CosmosGatewayRoute, SignedTokenTransferMessage } from './routes';
 
 export const fetchRedeemTx = async (
-  txData: ParsedMessage | ParsedRelayerMessage,
+  txData: SignedTokenTransferMessage,
 ): Promise<{ transactionHash: string } | null> => {
   let transactionHash: string | undefined;
   try {
@@ -35,7 +37,7 @@ export const fetchRedeemTx = async (
 };
 
 export const fetchRedeemedEvent = async (
-  txData: ParsedMessage | ParsedRelayerMessage,
+  txData: SignedTokenTransferMessage,
 ): Promise<{ transactionHash: string } | null> => {
   const messageId = getEmitterAndSequence(txData);
   const { emitterChain, emitterAddress, sequence } = messageId;
@@ -79,6 +81,9 @@ export const fetchRedeemedEvent = async (
       sequence,
     );
     return transactionHash ? { transactionHash } : null;
+  } else if (isCosmWasmChain(txData.toChain)) {
+    const hash = await new CosmosGatewayRoute().fetchRedeemedEvent(txData);
+    return hash ? { transactionHash: hash } : null;
   } else {
     const provider = wh.mustGetProvider(txData.toChain);
     const context: any = wh.getContext(
@@ -101,9 +106,7 @@ export const fetchRedeemedEvent = async (
   }
 };
 
-export const fetchSwapEvent = async (
-  txData: ParsedMessage | ParsedRelayerMessage,
-) => {
+export const fetchSwapEvent = async (txData: SignedTokenTransferMessage) => {
   const { tokenId, recipient, amount, tokenDecimals } = txData;
   if (txData.toChain === 'sui') {
     const context = wh.getContext(

--- a/wormhole-connect/src/utils/events.ts
+++ b/wormhole-connect/src/utils/events.ts
@@ -13,10 +13,10 @@ import { CHAINS } from 'config';
 import { fetchGlobalTx, getEmitterAndSequence } from './vaa';
 import { isEvmChain } from 'utils/sdk';
 import { isCosmWasmChain } from './cosmos';
-import { CosmosGatewayRoute, SignedTokenTransferMessage } from './routes';
+import { CosmosGatewayRoute, SignedMessage } from './routes';
 
 export const fetchRedeemTx = async (
-  txData: SignedTokenTransferMessage,
+  txData: SignedMessage,
 ): Promise<{ transactionHash: string } | null> => {
   let transactionHash: string | undefined;
   try {
@@ -37,7 +37,7 @@ export const fetchRedeemTx = async (
 };
 
 export const fetchRedeemedEvent = async (
-  txData: SignedTokenTransferMessage,
+  txData: SignedMessage,
 ): Promise<{ transactionHash: string } | null> => {
   const messageId = getEmitterAndSequence(txData);
   const { emitterChain, emitterAddress, sequence } = messageId;
@@ -106,7 +106,7 @@ export const fetchRedeemedEvent = async (
   }
 };
 
-export const fetchSwapEvent = async (txData: SignedTokenTransferMessage) => {
+export const fetchSwapEvent = async (txData: SignedMessage) => {
   const { tokenId, recipient, amount, tokenDecimals } = txData;
   if (txData.toChain === 'sui') {
     const context = wh.getContext(

--- a/wormhole-connect/src/utils/routes/cosmosGateway.ts
+++ b/wormhole-connect/src/utils/routes/cosmosGateway.ts
@@ -601,47 +601,28 @@ export class CosmosGatewayRoute extends BaseRoute {
       throw new Error(`Transaction ${hash} not found on chain ${chain}`);
     }
 
-    // Extract IBC transfer info initiated on the source chain
     const logs = cosmosLogs.parseRawLog(tx.rawLog);
-    const packetSeq = searchCosmosLogs('packet_sequence', logs);
-    const packetTimeout = searchCosmosLogs('packet_timeout_timestamp', logs);
-    const packetSrcChannel = searchCosmosLogs('packet_src_channel', logs);
-    const packetDstChannel = searchCosmosLogs('packet_dst_channel', logs);
-    if (
-      !packetSeq ||
-      !packetTimeout ||
-      !packetSrcChannel ||
-      !packetDstChannel
-    ) {
-      throw new Error('Missing packet information in transaction logs');
-    }
+    const sender = searchCosmosLogs('sender', logs);
+    if (!sender) throw new Error('Missing sender in transaction logs');
+
+    // Extract IBC transfer info initiated on the source chain
+    const ibcInfo = this.getIBCTransferInfoFromLogs(tx);
 
     // Look for the matching IBC receive on wormchain
     // The IBC hooks middleware will execute the translator contract
     // and include the execution logs on the transaction
     // which can be used to extract the VAA
-    const wormchainClient = await this.getCosmWasmClient(CHAIN_ID_WORMCHAIN);
-    const destTx = await wormchainClient.searchTx([
-      { key: 'recv_packet.packet_sequence', value: packetSeq },
-      { key: 'recv_packet.packet_timeout_timestamp', value: packetTimeout },
-      { key: 'recv_packet.packet_src_channel', value: packetSrcChannel },
-      { key: 'recv_packet.packet_dst_channel', value: packetDstChannel },
-    ]);
-    if (destTx.length === 0) {
+    const destTx = await this.findDestinationIBCTransferTx(
+      CHAIN_ID_WORMCHAIN,
+      ibcInfo,
+    );
+    if (!destTx) {
       throw new Error(
-        `No wormchain transaction found for packet by ${hash} on chain ${chain}`,
-      );
-    }
-    if (destTx.length > 1) {
-      throw new Error(
-        `Multiple transactions found for the same packet by ${hash} on chain ${chain}`,
+        `No wormchain transaction found for packet on chain ${chain}`,
       );
     }
 
-    const sender = searchCosmosLogs('sender', logs);
-    if (!sender) throw new Error('Missing sender in transaction logs');
-
-    const message = await wh.getMessage(destTx[0].hash, CHAIN_ID_WORMCHAIN);
+    const message = await wh.getMessage(destTx.hash, CHAIN_ID_WORMCHAIN);
     const parsed = await adaptParsedMessage(message);
 
     return {
@@ -695,6 +676,11 @@ export class CosmosGatewayRoute extends BaseRoute {
       message.toChain,
       ibcInfo,
     );
+    if (!destTx) {
+      throw new Error(
+        `No redeem transaction found on chain ${message.toChain}`,
+      );
+    }
     return destTx.hash;
   }
 
@@ -724,7 +710,7 @@ export class CosmosGatewayRoute extends BaseRoute {
   private async findDestinationIBCTransferTx(
     destChain: ChainName | ChainId,
     ibcInfo: IBCTransferInfo,
-  ): Promise<IndexedTx> {
+  ): Promise<IndexedTx | undefined> {
     const wormchainClient = await this.getCosmWasmClient(destChain);
     const destTx = await wormchainClient.searchTx([
       { key: 'recv_packet.packet_sequence', value: ibcInfo.sequence },
@@ -733,9 +719,7 @@ export class CosmosGatewayRoute extends BaseRoute {
       { key: 'recv_packet.packet_dst_channel', value: ibcInfo.dstChannel },
     ]);
     if (destTx.length === 0) {
-      throw new Error(
-        `No wormchain transaction found for packet on chain ${destChain}`,
-      );
+      return undefined;
     }
     if (destTx.length > 1) {
       throw new Error(

--- a/wormhole-connect/src/utils/routes/cosmosGateway.ts
+++ b/wormhole-connect/src/utils/routes/cosmosGateway.ts
@@ -11,6 +11,7 @@ import {
   calculateFee,
   logs as cosmosLogs,
   setupIbcExtension,
+  IndexedTx,
 } from '@cosmjs/stargate';
 import {
   ChainId,
@@ -68,6 +69,13 @@ interface GatewayTransferMsg {
 
 interface FromCosmosPayload {
   gateway_ibc_token_bridge_payload: GatewayTransferMsg;
+}
+
+interface IBCTransferInfo {
+  sequence: string;
+  timeout: string;
+  srcChannel: string;
+  dstChannel: string;
 }
 
 const IBC_MSG_TYPE = '/ibc.applications.transfer.v1.MsgTransfer';
@@ -640,6 +648,103 @@ export class CosmosGatewayRoute extends BaseRoute {
       sendTx: hash,
       sender,
     };
+  }
+
+  async fetchRedeemedEvent(
+    message: SignedTokenTransferMessage | SignedRelayTransferMessage,
+  ): Promise<string | null> {
+    return isCosmWasmChain(message.fromChain)
+      ? this.fetchRedeemedEventCosmosSource(message)
+      : this.fetchRedeemedEventNonCosmosSource(message);
+  }
+
+  private async fetchRedeemedEventNonCosmosSource(
+    message: SignedTokenTransferMessage | SignedRelayTransferMessage,
+  ): Promise<string | null> {
+    const wormchainClient = await this.getCosmWasmClient(CHAIN_ID_WORMCHAIN);
+    if (!message.payload) {
+      throw new Error('Missing payload from transfer');
+    }
+
+    // find the transaction on wormchain based on the gateway transfer payload
+    // since it has a nonce, we can assume it will be unique
+    const txs = await wormchainClient.searchTx([
+      { key: 'wasm.action', value: 'complete_transfer_with_payload' },
+      { key: 'wasm.recipient', value: this.getTranslatorAddress() },
+      {
+        key: 'wasm.transfer_payload',
+        value: Buffer.from(utils.arrayify(message.payload)).toString('base64'),
+      },
+    ]);
+    if (txs.length === 0) {
+      return null;
+    }
+    if (txs.length > 1) {
+      throw new Error('Multiple transactions found');
+    }
+
+    // extract the ibc transfer info from the transaction logs
+    const ibcInfo = this.getIBCTransferInfoFromLogs(txs[0]);
+
+    // find the transaction on the target chain based on the ibc transfer info
+    const destTx = await this.findDestinationIBCTransferTx(
+      message.toChain,
+      ibcInfo,
+    );
+    return destTx.hash;
+  }
+
+  private getIBCTransferInfoFromLogs(tx: IndexedTx): IBCTransferInfo {
+    const logs = cosmosLogs.parseRawLog(tx.rawLog);
+    const packetSeq = searchCosmosLogs('packet_sequence', logs);
+    const packetTimeout = searchCosmosLogs('packet_timeout_timestamp', logs);
+    const packetSrcChannel = searchCosmosLogs('packet_src_channel', logs);
+    const packetDstChannel = searchCosmosLogs('packet_dst_channel', logs);
+    if (
+      !packetSeq ||
+      !packetTimeout ||
+      !packetSrcChannel ||
+      !packetDstChannel
+    ) {
+      throw new Error('Missing packet information in transaction logs');
+    }
+
+    return {
+      sequence: packetSeq,
+      timeout: packetTimeout,
+      srcChannel: packetSrcChannel,
+      dstChannel: packetDstChannel,
+    };
+  }
+
+  private async findDestinationIBCTransferTx(
+    destChain: ChainName | ChainId,
+    ibcInfo: IBCTransferInfo,
+  ): Promise<IndexedTx> {
+    const wormchainClient = await this.getCosmWasmClient(destChain);
+    const destTx = await wormchainClient.searchTx([
+      { key: 'recv_packet.packet_sequence', value: ibcInfo.sequence },
+      { key: 'recv_packet.packet_timeout_timestamp', value: ibcInfo.timeout },
+      { key: 'recv_packet.packet_src_channel', value: ibcInfo.srcChannel },
+      { key: 'recv_packet.packet_dst_channel', value: ibcInfo.dstChannel },
+    ]);
+    if (destTx.length === 0) {
+      throw new Error(
+        `No wormchain transaction found for packet on chain ${destChain}`,
+      );
+    }
+    if (destTx.length > 1) {
+      throw new Error(
+        `Multiple transactions found for the same packet on chain ${destChain}`,
+      );
+    }
+    return destTx[0];
+  }
+
+  private async fetchRedeemedEventCosmosSource(
+    message: SignedTokenTransferMessage | SignedRelayTransferMessage,
+  ): Promise<string | null> {
+    throw new Error('Not implemented');
   }
 
   async getTransferSourceInfo({

--- a/wormhole-connect/src/utils/routes/cosmosGateway.ts
+++ b/wormhole-connect/src/utils/routes/cosmosGateway.ts
@@ -635,9 +635,11 @@ export class CosmosGatewayRoute extends BaseRoute {
     };
   }
 
-  async fetchRedeemedEvent(
-    message: SignedTokenTransferMessage | SignedRelayTransferMessage,
-  ): Promise<string | null> {
+  async fetchRedeemedEvent(message: SignedMessage): Promise<string | null> {
+    if (!isSignedWormholeMessage(message)) {
+      throw new Error('Signed message is not for gateway');
+    }
+
     return isCosmWasmChain(message.fromChain)
       ? this.fetchRedeemedEventCosmosSource(message)
       : this.fetchRedeemedEventNonCosmosSource(message);

--- a/wormhole-connect/src/utils/routes/cosmosGateway.ts
+++ b/wormhole-connect/src/utils/routes/cosmosGateway.ts
@@ -30,7 +30,7 @@ import {
   TendermintClient,
 } from '@cosmjs/tendermint-rpc';
 import { BigNumber, utils } from 'ethers';
-import { arrayify, hexlify } from 'ethers/lib/utils.js';
+import { arrayify } from 'ethers/lib/utils.js';
 import { toChainId, wh } from 'utils/sdk';
 import { isCosmWasmChain } from 'utils/cosmos';
 import { CHAINS, RPCS, ROUTES, TOKENS } from 'config';
@@ -512,15 +512,19 @@ export class CosmosGatewayRoute extends BaseRoute {
     return CosmWasmClient.create(tmClient);
   }
 
-  isTransferCompleted(
+  async isTransferCompleted(
     destChain: ChainName | ChainId,
     message: SignedMessage,
   ): Promise<boolean> {
     if (!isSignedWormholeMessage(message))
       throw new Error('Signed message is not for gateway');
-    return isCosmWasmChain(destChain)
-      ? wh.isTransferCompleted(CHAIN_ID_WORMCHAIN, hexlify(message.vaa))
-      : new BridgeRoute().isTransferCompleted(destChain, message);
+
+    if (!isCosmWasmChain(destChain)) {
+      return new BridgeRoute().isTransferCompleted(destChain, message);
+    }
+
+    const destTx = await this.fetchRedeemedEvent(message);
+    return !!destTx;
   }
 
   async getMessage(

--- a/wormhole-connect/src/utils/routes/relay.ts
+++ b/wormhole-connect/src/utils/routes/relay.ts
@@ -485,7 +485,8 @@ export class RelayRoute extends BridgeRoute {
     receiveTx,
     transferComplete,
   }: TransferDestInfoParams): Promise<TransferDisplayData> {
-    const txData: ParsedRelayerMessage = data as ParsedRelayerMessage;
+    const txData: SignedRelayTransferMessage =
+      data as SignedRelayTransferMessage;
 
     const token = TOKENS[txData.tokenKey];
     const { gasToken } = CHAINS[txData.toChain]!;

--- a/wormhole-connect/src/views/Redeem/SendTo.tsx
+++ b/wormhole-connect/src/views/Redeem/SendTo.tsx
@@ -24,6 +24,7 @@ import Spacer from 'components/Spacer';
 import WalletsModal from '../WalletModal';
 import Header from './Header';
 import { estimateClaimGas } from 'utils/gas';
+import { isCosmWasmChain } from '../../utils/cosmos';
 
 function SendTo() {
   const dispatch = useDispatch();
@@ -100,8 +101,11 @@ function SendTo() {
 
   const AUTOMATIC_DEPOSIT = useMemo(() => {
     if (!routeName) return false;
-    return RouteOperator.getRoute(routeName).AUTOMATIC_DEPOSIT;
-  }, [routeName]);
+    return (
+      RouteOperator.getRoute(routeName).AUTOMATIC_DEPOSIT ||
+      isCosmWasmChain(txData.toChain)
+    );
+  }, [routeName, txData]);
 
   const claim = async () => {
     setInProgress(true);


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added support for CosmWasm chains in the Wormhole SDK. This includes handling of CosmWasm specific transactions and events.
- Refactor: Abstracted the retrieval of Cosmos network client into a separate function, improving code modularity.
- Refactor: Updated various function signatures to accept `SignedMessage` parameter, enhancing type consistency across the codebase.
- New Feature: Introduced `fetchRedeemedEvent` method in `CosmosGatewayRoute` class to fetch redeemed events based on message type.
- Refactor: Extracted IBC transfer information extraction from transaction logs into a separate method, improving code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->